### PR TITLE
IPv6 support and additional PNA bypasses

### DIFF
--- a/commandcontrol.go
+++ b/commandcontrol.go
@@ -396,7 +396,7 @@ func (c *WSClient) keepAlive(wscss *WebsocketClientStateStore, sessionID string)
 	}
 }
 
-//RoundTrip is a custom RoundTrip implementation for reverse proxy to websocket
+// RoundTrip is a custom RoundTrip implementation for reverse proxy to websocket
 func (t *ProxytoWebsocketTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	headers := make(map[string]string)
 
@@ -608,7 +608,7 @@ func (ws *WebsocketHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	defer c.Close()
 
-	name, err := NewDNSQuery(r.Header.Get("origin"))
+	name, err := NewDNSQueryFromOrigin(r.Header.Get("origin"))
 
 	if err != nil {
 		log.Printf("websockets: could not parse origin hostname: %v\n", err)


### PR DESCRIPTION
### Added Basic Experimental Support for IPv6.

This changes the DNS name and URLs format from e.g.:

- "s-ip.ad.dr.ss-127.0.0.1-<random_number>-fs-e.dynamic.your.domain"

to:

- "s-X.Y-<random_number>-fs-e.dynamic.your.domain"

where X and Y are either 4 bytes (IPv4), or 16 bytes (IPv6) hexstrings, or CNAMEs e.g. "localhost".

Sample (re-)tested configurations in Firefox:

- IPv4 public to 127.0.01 (First then Second, fetch API)
- IPv4 public to 127.0.01 (Multiple Answers, fetch API)
- IPv4 public to "localhost" CNAME (First then Second, fetch API)
- IPv6 public to :: (First then Second, fetch API)
- IPv6 public to :: (Multiple Answers, fetch API)  

Sample tested PNA bypasses working in Chrome:

- IPv6 public to 127.0.0.1 in ~3 seconds (Multiple Answers, inline frame) 
- IPv6 public to :: in ~3 seconds (Multiple Answers, inline frame)
- IPv6 public to 0.0.0.0 in ~3 seconds (Multiple Answers, inline frame)

### Added `-ignoreDNSRequestFrom` Command Line Option

Permits to ignore spurious DNS requests from third-parties that interfere with Singularity's DNS rebinding sessions with targets.
